### PR TITLE
Add codepipeline_healthcheck module

### DIFF
--- a/codepipeline_healthcheck/cloudwatch.tf
+++ b/codepipeline_healthcheck/cloudwatch.tf
@@ -1,0 +1,32 @@
+resource "aws_cloudwatch_event_rule" "codepipeline_event_rule" {
+  name        = "codepipeline-${var.pipeline_name}-healthcheck-event-rule"
+  description = "Codepipeline Execution State Change"
+
+  event_pattern = <<EOF
+{
+  "source": [
+    "aws.codepipeline"
+  ],
+  "detail-type": [
+    "CodePipeline Pipeline Execution State Change"
+  ],
+  "detail": {
+    "pipeline": [
+      "${var.pipeline_name}"
+    ],
+    "state": [
+      "SUCCEEDED",
+      "FAILED",
+      "STARTED",
+      "ABANDONED"
+    ]
+  }
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "sns" {
+  rule      = aws_cloudwatch_event_rule.codepipeline_event_rule.name
+  target_id = "SendToSNS"
+  arn       = data.aws_sns_topic.health_notification.arn
+}

--- a/codepipeline_healthcheck/sns.tf
+++ b/codepipeline_healthcheck/sns.tf
@@ -1,3 +1,22 @@
 data "aws_sns_topic" "health_notification" {
   name = var.health_notification_topic_name
 }
+
+resource "aws_sns_topic_policy" "default" {
+  arn    = data.aws_sns_topic.health_notification.arn
+  policy = data.aws_iam_policy_document.events_to_sns.json
+}
+
+data "aws_iam_policy_document" "events_to_sns" {
+  statement {
+    effect  = "Allow"
+    actions = ["SNS:Publish"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    resources = [data.aws_sns_topic.health_notification.arn]
+  }
+}

--- a/codepipeline_healthcheck/sns.tf
+++ b/codepipeline_healthcheck/sns.tf
@@ -1,0 +1,3 @@
+data "aws_sns_topic" "health_notification" {
+  name = var.health_notification_topic_name
+}

--- a/codepipeline_healthcheck/variables.tf
+++ b/codepipeline_healthcheck/variables.tf
@@ -1,0 +1,10 @@
+variable "pipeline_name" {
+  type        = string
+  description = "Name of the pipeline we're creating a health notification event for"
+}
+
+variable "health_notification_topic_name" {
+  type        = string
+  default     = "codepipeline-health-notification"
+  description = "Name of the SNS topic used for the health notification"
+}

--- a/codepipeline_healthcheck/variables.tf
+++ b/codepipeline_healthcheck/variables.tf
@@ -5,6 +5,5 @@ variable "pipeline_name" {
 
 variable "health_notification_topic_name" {
   type        = string
-  default     = "codepipeline-health-notification"
   description = "Name of the SNS topic used for the health notification"
 }

--- a/codepipeline_healthcheck/versions.tf
+++ b/codepipeline_healthcheck/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Parameterised the pipeline name and SNS topic from
https://github.com/alphagov/cyber-security-authenticate/blob/code-pipeline-evaluation/terraform/modules/pipeline/cloudwatch.tf
but set a default for the SNS topic since I think all the CodePipeline
pipelines want to use the same topic for health notifications.

Paired with @MahmudH (edit 2021-08-02: and @alice-carr)