### PR TITLE
Add `registry_credentials` block and related data source and vars

### DIFF
--- a/codebuild/codebuild_terraform_apply/code_build_terraform.tf
+++ b/codebuild/codebuild_terraform_apply/code_build_terraform.tf
@@ -20,6 +20,11 @@ resource "aws_codebuild_project" "code_pipeline_terraform" {
     image_pull_credentials_type = "SERVICE_ROLE"
     privileged_mode             = false
 
+    registry_credential {
+      credential_provider = "SECRETS_MANAGER"
+      credential          = data.aws_secretsmanager_secret.dockerhub_creds.arn
+    }
+
     environment_variable {
       name  = "AWS_ACCOUNT_ID"
       value = var.deployment_account_id

--- a/codebuild/codebuild_terraform_apply/data_buildassets.tf
+++ b/codebuild/codebuild_terraform_apply/data_buildassets.tf
@@ -1,3 +1,7 @@
 data "aws_iam_role" "execution_role" {
   name = var.codebuild_service_role_name
 }
+
+data "aws_secretsmanager_secret" "dockerhub_creds" {
+  name = var.docker_hub_credentials
+}

--- a/codebuild/codebuild_terraform_apply/variables.tf
+++ b/codebuild/codebuild_terraform_apply/variables.tf
@@ -49,3 +49,8 @@ variable "environment" {
   description = "e.g. staging, production"
   type        = string
 }
+
+variable "docker_hub_credentials" {
+  description = "The name of the Secrets Manager secret that contains the username and password for the Docker Hub"
+  type        = string
+}


### PR DESCRIPTION
I just realised that this was why we had a Too Many Requests (HAP429)
error in some invocations of the pipeline. Can't believe we forgot this.

TODO: Make this optional?