### PR TITLE
Add module READMEs

### DIFF
--- a/codebuild/codebuild_project_container_build_docker_hub/README.md
+++ b/codebuild/codebuild_project_container_build_docker_hub/README.md
@@ -1,0 +1,80 @@
+# CodeBuild Container Build and Push to Docker Hub module
+
+This module creates a CodeBuild project.
+
+## Example Usage
+```terraform
+module "codebuild-dockerhub-build" {
+  source              = "github.com/alphagov/cyber-security-shared-terraform-modules//codebuild/codebuild_project_container_build_docker_hub"
+  service_role_name   = "example-codebuild-service-role"
+  docker_hub_repo     = "username/image_name"
+  build_context       = "."
+  dockerfile          = "Dockerfile"
+  docker_hub_username = "example-username"
+  docker_hub_password = "example-password"
+  pipeline_name       = "example-pipeline"
+  environment         = "test"
+}
+
+resource "aws_codepipeline" "example-pipeline" {
+  name = "example-pipeline"
+  ...
+
+  stage {
+    name = "Source"
+    
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["git_repo"]
+      configuration = {
+        ...
+      }
+    }
+  }
+
+  stage {
+    name = "DockerBuildAndPush"
+
+    action {
+      name             = "DockerBuildAndPush"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      version          = "1"
+      run_order        = 1
+      input_artifacts  = ["git_repo"]
+      output_artifacts = []
+
+      configuration = {
+        ProjectName = module.codebuild-dockerhub-build.project_name
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+The following arguments are required:
+- `service_role_name` - The name of the CodeBuild service role to use for this project.
+- `docker_hub_repo` - The repository on Docker Hub, in the format `username/image_name`.
+- `build_context` - The path to the folder you want to use as context for building the image,
+  relative to the root of the repo passed into the CodeBuild project.
+- `dockerfile` - The path to the Dockerfile that defines the image, relative to the root of the repo
+  passed into the CodeBuild project.
+- `docker_hub_username` - The username used to authenticate with Docker Hub.
+- `docker_hub_password` - The password used to authenticate with Docker Hub.
+- `pipeline_name` - The name of the pipeline this project will be a part of. (Technically this can
+  be anything, but it helps with associating the CodeBuild projects with their respective pipelines)
+- `environment` - The environment, such as "staging" or "production".
+
+The following arguments are optional:
+- `image_tag` - The tag to apply to the image. `latest` by default.
+
+## Attributes Reference
+This module has a single output:
+- `project_name` - The name of the created CodeBuild project. In the `configuration` block of the
+  CodePipeline `action` you want to use this project in, set `ProjectName` to this value.

--- a/codebuild/codebuild_terraform_apply/README.md
+++ b/codebuild/codebuild_terraform_apply/README.md
@@ -3,8 +3,13 @@
 This module creates a CodeBuild project.
 
 The CodeBuild project deploys Terraform resources from a given directory in its environment, using a
-given AWS role to grant the necessary permissions to make the changes. It is designed to be used
-within a CodePipeline pipeline.
+given AWS role to grant the necessary permissions to make the changes.
+
+In the `post_build` step, the CodeBuild project writes the output of the command `terraform output
+-json` to a file, which is marked as an artifact that can be uploaded.
+
+It is designed to be used within a CodePipeline pipeline.
+
 
 ## Example Usage
 ```terraform
@@ -51,7 +56,7 @@ resource "aws_codepipeline" "example-pipeline" {
       version          = "1"
       run_order        = 1
       input_artifacts  = ["git_repo"]
-      output_artifacts = []
+      output_artifacts = ["terraform_output"]
 
       configuration = {
         ProjectName = module.codebuild-terraform-apply.project_name
@@ -84,6 +89,10 @@ The following arguments are optional:
   file
 - `apply_var_file` - If you use a var file during `terraform apply`, set this to the path of that
   file
+- `service_name` - This is used to modify the name of the JSON file that contains the output of
+  `terraform output -json`. You may want to change this from the default if:
+  - You need to reference the `terraform output` artifact, and
+  - You use this module for multiple different Terraform deployments in the same target account.
 
 ## Attributes Reference
 This module has a single output:

--- a/codebuild/codebuild_terraform_apply/README.md
+++ b/codebuild/codebuild_terraform_apply/README.md
@@ -1,0 +1,91 @@
+# CodeBuild Terraform Apply module
+
+This module creates a CodeBuild project.
+
+The CodeBuild project deploys Terraform resources from a given directory in its environment, using a
+given AWS role to grant the necessary permissions to make the changes. It is designed to be used
+within a CodePipeline pipeline.
+
+## Example Usage
+```terraform
+module "codebuild-terraform-apply" {
+  source                      = "github.com/alphagov/cyber-security-shared-terraform-modules//codebuild/codebuild_terraform_apply"
+  codebuild_service_role_name = "example-codebuild-service-role"
+  deployment_account_id       = 123456789012
+  deployment_role_name        = "example-deployment-role"
+  terraform_directory         = "terraform/deployments/123456789012"
+  codebuild_image             = "repository/image_name"
+  pipeline_name               = "example-pipeline"
+  environment                 = "test"
+  docker_hub_credentials      = "example-secret-name"
+}
+
+resource "aws_codepipeline" "example-pipeline" {
+  name = "example-pipeline"
+  ...
+
+  stage {
+    name = "Source"
+    
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["git_repo"]
+      configuration = {
+        ...
+      }
+    }
+  }
+
+  stage {
+    name = "TerraformApply"
+
+    action {
+      name             = "TerraformApply"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      version          = "1"
+      run_order        = 1
+      input_artifacts  = ["git_repo"]
+      output_artifacts = []
+
+      configuration = {
+        ProjectName = module.codebuild-terraform-apply.project_name
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+The following arguments are required:
+- `codebuild_service_role_name` - The name of the CodeBuild service role to use for this project.
+- `deployment_account_id` - The ID number of the AWS account that the resources defined in the
+  Terraform will be deployed to.
+- `deployment_role_name` - The name of the IAM Role that will be assumed into to grant the
+  permissions required to make changes in the deployment account. **The service role referred to by
+  `codebuild_service_role_name` must be able to assume this role.**
+- `terraform_directory` - The path to the directory that has the Terraform you want to deploy,
+  relative to the root of the repo passed into the CodeBuild project.
+- `codebuild_image` - The name of the DockerHub image to use for the CodeBuild project, in the form
+  `username/image_name`.
+- `pipeline_name` - The name of the pipeline this project will be a part of. (Technically this can
+  be anything, but it helps with associating the CodeBuild projects with their respective pipelines)
+- `environment` - The environment, such as "staging" or "production".
+- `docker_hub_credentials` - The name of the Secrets Manager secret that contains the Docker Hub
+  username and password, used to pull the image defined in `codebuild_image`.
+
+The following arguments are optional:
+- `backend_var_file` - If you use a var file during `terraform init`, set this to the path of that
+  file
+- `apply_var_file` - If you use a var file during `terraform apply`, set this to the path of that
+  file
+
+## Attributes Reference
+This module has a single output:
+- `project_name` - The name of the created CodeBuild project. In the `configuration` block of the
+  CodePipeline `action` you want to use this project in, set `ProjectName` to this value.

--- a/codebuild/codebuild_terraform_apply/README.md
+++ b/codebuild/codebuild_terraform_apply/README.md
@@ -93,6 +93,8 @@ The following arguments are optional:
   `terraform output -json`. You may want to change this from the default if:
   - You need to reference the `terraform output` artifact, and
   - You use this module for multiple different Terraform deployments in the same target account.
+  
+  Defaults to `"terraform_output"`
 
 ## Attributes Reference
 This module has a single output:

--- a/codepipeline_healthcheck/README.md
+++ b/codepipeline_healthcheck/README.md
@@ -1,0 +1,31 @@
+# CodePipeline Healthcheck Event Rule
+
+This module creates a CloudWatch/EventBridge Event Rule, an SNS topic target for that rule, and a
+policy for the SNS topic to allow the event rule to publish to it.
+
+The Event Rule watches a given CodePipeline pipeline for any state changes, sending those state
+changes to the SNS topic.
+
+## Example Usage
+```terraform
+module "codepipeline-healthcheck" {
+  source                         = "github.com/alphagov/cyber-security-shared-terraform-modules//codepipeline_healthcheck"
+  pipeline_name                  = "example_pipeline
+  health_notification_topic_name = "example_topic"
+}
+
+resource "aws_codepipeline" "example_pipeline" {
+  name = "example_pipeline"
+  ...
+}
+
+resource "aws_sns_topic" "example_topic" {
+  name = "example_topic"
+  ...
+}
+```
+
+## Argument Reference
+The following arguments are required:
+- `pipeline_name` - The name of the CodePipeline pipeline to track the state of.
+- `health_notification_topic_name` - The name of the SNS topic to publish to.


### PR DESCRIPTION
Used the Terraform resource documentation as a reference for the layout of these READMEs. The Example Usage section might be a bit too detailed (or not detailed enough?), so I would appreciate some refinement there. Didn't get around to the ECR module, so I would appreciate that to be added.

I also removed an empty file in the `codepipeline-healthcheck` folder with this PR.