### PR TITLE
Tag codebuild projects

### DIFF
--- a/codebuild/codebuild_build_container_docker_hub/codebuild_build_container_docker_hub.tf
+++ b/codebuild/codebuild_build_container_docker_hub/codebuild_build_container_docker_hub.tf
@@ -1,5 +1,8 @@
+locals {
+  cbp_dockerhub_name = "${var.pipeline_name}-build-container-docker-hub-${var.environment}"
+}
 resource "aws_codebuild_project" "codebuild_build_container_docker_hub" {
-  name        = "${var.pipeline_name}-build-container-docker-hub-${var.environment}"
+  name        = local.cbp_dockerhub_name
   description = "Build and push images to dockerhub"
 
   service_role = data.aws_iam_role.execution_role.arn
@@ -56,7 +59,7 @@ resource "aws_codebuild_project" "codebuild_build_container_docker_hub" {
     buildspec = file("${path.module}/codebuild_build_container_docker_hub.yml")
   }
 
-  tags = merge(var.tags,{"Name": self.name})
+  tags = merge(var.tags,{"Name": local.cbp_dockerhub_name})
 }
 
 data "aws_iam_role" "execution_role" {

--- a/codebuild/codebuild_build_container_docker_hub/codebuild_build_container_docker_hub.tf
+++ b/codebuild/codebuild_build_container_docker_hub/codebuild_build_container_docker_hub.tf
@@ -55,6 +55,8 @@ resource "aws_codebuild_project" "codebuild_build_container_docker_hub" {
     type      = "CODEPIPELINE"
     buildspec = file("${path.module}/codebuild_build_container_docker_hub.yml")
   }
+
+  tags = merge(var.tags,{"Name": self.name})
 }
 
 data "aws_iam_role" "execution_role" {

--- a/codebuild/codebuild_build_container_docker_hub/codebuild_build_container_docker_hub.tf
+++ b/codebuild/codebuild_build_container_docker_hub/codebuild_build_container_docker_hub.tf
@@ -1,8 +1,9 @@
 locals {
-  cbp_dockerhub_name = "${var.pipeline_name}-build-container-docker-hub-${var.environment}"
+  codebuild_project_name = "${var.pipeline_name}-build-container-docker-hub-${var.environment}"
 }
+
 resource "aws_codebuild_project" "codebuild_build_container_docker_hub" {
-  name        = local.cbp_dockerhub_name
+  name        = local.codebuild_project_name
   description = "Build and push images to dockerhub"
 
   service_role = data.aws_iam_role.execution_role.arn
@@ -59,7 +60,7 @@ resource "aws_codebuild_project" "codebuild_build_container_docker_hub" {
     buildspec = file("${path.module}/codebuild_build_container_docker_hub.yml")
   }
 
-  tags = merge(var.tags,{"Name": local.cbp_dockerhub_name})
+  tags = merge(var.tags, { "Name" : local.codebuild_project_name })
 }
 
 data "aws_iam_role" "execution_role" {

--- a/codebuild/codebuild_build_container_docker_hub/variables.tf
+++ b/codebuild/codebuild_build_container_docker_hub/variables.tf
@@ -44,3 +44,8 @@ variable "docker_hub_password" {
   description = "Dockerhub password"
   # sensitive   = true # Terraform 0.14+ only
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Pass through parent service tags to CodeBuild project resource"
+}

--- a/codebuild/codebuild_build_container_docker_hub/variables.tf
+++ b/codebuild/codebuild_build_container_docker_hub/variables.tf
@@ -48,4 +48,5 @@ variable "docker_hub_password" {
 variable "tags" {
   type        = map(string)
   description = "Pass through parent service tags to CodeBuild project resource"
+  default     = {}
 }

--- a/codebuild/codebuild_build_container_ecr/codebuild_build_container_ecr.tf
+++ b/codebuild/codebuild_build_container_ecr/codebuild_build_container_ecr.tf
@@ -1,5 +1,8 @@
+locals {
+  codebuild_project_name = "${var.pipeline_name}-build-container-ecr-${var.environment}"
+}
 resource "aws_codebuild_project" "codebuild_build_container_ecr" {
-  name        = "${var.pipeline_name}-build-container-ecr-${var.environment}"
+  name        = local.codebuild_project_name
   description = "Build container and push to ECR"
 
   service_role = data.aws_iam_role.execution_role.arn
@@ -66,4 +69,6 @@ resource "aws_codebuild_project" "codebuild_build_container_ecr" {
     type      = "CODEPIPELINE"
     buildspec = file("${path.module}/codebuild_build_container_ecr.yml")
   }
+
+  tags = merge(var.tags, { "Name" : local.codebuild_project_name })
 }

--- a/codebuild/codebuild_build_container_ecr/variables.tf
+++ b/codebuild/codebuild_build_container_ecr/variables.tf
@@ -55,3 +55,9 @@ variable "docker_hub_password" {
   type        = string
   # sensitive   = true # Terraform 0.14 only, unfortunately
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Pass through parent service tags to CodeBuild project resource"
+  default     = {}
+}

--- a/codebuild/codebuild_get_actions_required/codebuild_get_actions_required.tf
+++ b/codebuild/codebuild_get_actions_required/codebuild_get_actions_required.tf
@@ -1,5 +1,9 @@
+locals {
+  codebuild_project_name = "${var.pipeline_name}-get-actions-required-${var.environment}"
+}
+
 resource "aws_codebuild_project" "code_pipeline_get_actions_required" {
-  name        = "${var.pipeline_name}-get-actions-required-${var.environment}"
+  name        = local.codebuild_project_name
   description = "Reads changed_files.json and actions_triggers.json to produce actions_required.json."
 
   service_role = data.aws_iam_role.execution_role.arn
@@ -13,7 +17,7 @@ resource "aws_codebuild_project" "code_pipeline_get_actions_required" {
     name                = "actions_required.json"
     artifact_identifier = "actions_required"
     location            = var.artifact_bucket
-    path                = var.output_artifact_path 
+    path                = var.output_artifact_path
   }
 
   cache {
@@ -49,4 +53,6 @@ resource "aws_codebuild_project" "code_pipeline_get_actions_required" {
     type      = "CODEPIPELINE"
     buildspec = file("${path.module}/codebuild_get_actions_required.yml")
   }
+
+  tags = merge(var.tags, { "Name" : local.codebuild_project_name })
 }

--- a/codebuild/codebuild_get_actions_required/variables.tf
+++ b/codebuild/codebuild_get_actions_required/variables.tf
@@ -39,6 +39,12 @@ variable "codebuild_image" {
 }
 
 variable "action_triggers" {
-    description = "the path to the action_triggers.json file in your repo, relative to the root of the repo."
-    type        = string
+  description = "the path to the action_triggers.json file in your repo, relative to the root of the repo."
+  type        = string
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Pass through parent service tags to CodeBuild project resource"
+  default     = {}
 }

--- a/codebuild/codebuild_get_changed_file_list/variables.tf
+++ b/codebuild/codebuild_get_changed_file_list/variables.tf
@@ -58,3 +58,9 @@ variable "docker_hub_credentials" {
   description = "The name of the Secrets Manager secret that contains the username and password for the Docker Hub"
   type        = string
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Pass through parent service tags to CodeBuild project resource"
+  default     = {}
+}

--- a/codebuild/codebuild_python_tox/code_build_python_tox.tf
+++ b/codebuild/codebuild_python_tox/code_build_python_tox.tf
@@ -1,5 +1,8 @@
+locals {
+  codebuild_project_name = "${var.pipeline_name}-python-tox-${var.environment}"
+}
 resource "aws_codebuild_project" "code_pipeline_python_tox" {
-  name        = "${var.pipeline_name}-python-tox-${var.environment}"
+  name        = local.codebuild_project_name
   description = "Run Python tox"
 
   service_role = data.aws_iam_role.execution_role.arn
@@ -50,4 +53,6 @@ resource "aws_codebuild_project" "code_pipeline_python_tox" {
     type      = "CODEPIPELINE"
     buildspec = file("${path.module}/code_build_python_tox.yml")
   }
+
+  tags = merge(var.tags, { "Name" : local.codebuild_project_name })
 }

--- a/codebuild/codebuild_python_tox/variables.tf
+++ b/codebuild/codebuild_python_tox/variables.tf
@@ -13,7 +13,6 @@ variable "deployment_role_name" {
   type        = string
 }
 
-
 variable "codebuild_service_role_name" {
   description = "the role code build uses to access other AWS services"
   type        = string
@@ -47,4 +46,10 @@ variable "environment" {
 variable "docker_hub_credentials" {
   description = "The name of the Secrets Manager secret that contains the username and password for the Docker Hub"
   type        = string
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Pass through parent service tags to CodeBuild project resource"
+  default     = {}
 }

--- a/codebuild/codebuild_terraform_apply/code_build_terraform.tf
+++ b/codebuild/codebuild_terraform_apply/code_build_terraform.tf
@@ -1,5 +1,8 @@
+locals {
+  codebuild_project_name = "${var.pipeline_name}-terraform-${var.environment}"
+}
 resource "aws_codebuild_project" "code_pipeline_terraform" {
-  name        = "${var.pipeline_name}-terraform-${var.environment}"
+  name        = local.codebuild_project_name
   description = "Run terraform validate and then terraform apply"
 
   service_role = data.aws_iam_role.execution_role.arn
@@ -60,4 +63,6 @@ resource "aws_codebuild_project" "code_pipeline_terraform" {
     type      = "CODEPIPELINE"
     buildspec = file("${path.module}/code_build_terraform.yml")
   }
+
+  tags = merge(var.tags, { "Name" : local.codebuild_project_name })
 }

--- a/codebuild/codebuild_terraform_apply/variables.tf
+++ b/codebuild/codebuild_terraform_apply/variables.tf
@@ -54,3 +54,9 @@ variable "docker_hub_credentials" {
   description = "The name of the Secrets Manager secret that contains the username and password for the Docker Hub"
   type        = string
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Pass through parent service tags to CodeBuild project resource"
+  default     = {}
+}


### PR DESCRIPTION
Tags var defaults to an empty map
Each codebuild module declares the codebuild project name as a local var
By default at least a Name tag will be applied.
If tags is specified the derived Name tag is added to the existing map

I've done a plan on the concourse-base-image to test this works but I won't PR that until this change is merged. 