### PR TITLE
CE-265 Refactor module interfaces to ensure unique names of codebuild projects

### DIFF
--- a/codebuild/codebuild_apply_terraform/code_build_terraform.tf
+++ b/codebuild/codebuild_apply_terraform/code_build_terraform.tf
@@ -1,5 +1,5 @@
 locals {
-  codebuild_project_name = "${var.pipeline_name}-terraform-${var.environment}"
+  codebuild_project_name = "${var.pipeline_name}-${var.stage_name}-${var.action_name}"
 }
 resource "aws_codebuild_project" "code_pipeline_terraform" {
   name        = local.codebuild_project_name

--- a/codebuild/codebuild_apply_terraform/variables.tf
+++ b/codebuild/codebuild_apply_terraform/variables.tf
@@ -45,6 +45,18 @@ variable "pipeline_name" {
   type        = string
 }
 
+variable "stage_name" {
+  description = "The name of the pipeline stage"
+  type        = string
+  default     = "default"
+}
+
+variable "action_name" {
+  description = "The name of the pipeline stage action"
+  type        = string
+  default     = "default"
+}
+
 variable "environment" {
   description = "e.g. staging, production"
   type        = string

--- a/codebuild/codebuild_build_container_docker_hub/codebuild_build_container_docker_hub.tf
+++ b/codebuild/codebuild_build_container_docker_hub/codebuild_build_container_docker_hub.tf
@@ -1,5 +1,5 @@
 locals {
-  codebuild_project_name = "${var.pipeline_name}-build-container-docker-hub-${var.environment}"
+  codebuild_project_name = "${var.pipeline_name}-${var.stage_name}-${var.action_name}"
 }
 
 resource "aws_codebuild_project" "codebuild_build_container_docker_hub" {

--- a/codebuild/codebuild_build_container_docker_hub/variables.tf
+++ b/codebuild/codebuild_build_container_docker_hub/variables.tf
@@ -19,6 +19,18 @@ variable "pipeline_name" {
   description = "Name of the pipeline"
 }
 
+variable "stage_name" {
+  description = "The name of the pipeline stage"
+  type        = string
+  default     = "default"
+}
+
+variable "action_name" {
+  description = "The name of the pipeline stage action"
+  type        = string
+  default     = "default"
+}
+
 variable "environment" {
   type        = string
   description = "Enviroment this module will be ran"

--- a/codebuild/codebuild_build_container_ecr/codebuild_build_container_ecr.tf
+++ b/codebuild/codebuild_build_container_ecr/codebuild_build_container_ecr.tf
@@ -1,5 +1,5 @@
 locals {
-  codebuild_project_name = "${var.pipeline_name}-build-container-ecr-${var.environment}"
+  codebuild_project_name = "${var.pipeline_name}-${var.stage_name}-${var.action_name}"
 }
 resource "aws_codebuild_project" "codebuild_build_container_ecr" {
   name        = local.codebuild_project_name

--- a/codebuild/codebuild_build_container_ecr/variables.tf
+++ b/codebuild/codebuild_build_container_ecr/variables.tf
@@ -8,6 +8,18 @@ variable "pipeline_name" {
   description = "Name of the pipeline"
 }
 
+variable "stage_name" {
+  description = "The name of the pipeline stage"
+  type        = string
+  default     = "default"
+}
+
+variable "action_name" {
+  description = "The name of the pipeline stage action"
+  type        = string
+  default     = "default"
+}
+
 variable "dockerfile" {
   type        = string
   description = "Dockerfile to be used to build image"

--- a/codebuild/codebuild_get_actions_required/codebuild_get_actions_required.tf
+++ b/codebuild/codebuild_get_actions_required/codebuild_get_actions_required.tf
@@ -1,5 +1,5 @@
 locals {
-  codebuild_project_name = "${var.pipeline_name}-get-actions-required-${var.environment}"
+  codebuild_project_name = "${var.pipeline_name}-${var.stage_name}-${var.action_name}"
 }
 
 resource "aws_codebuild_project" "code_pipeline_get_actions_required" {

--- a/codebuild/codebuild_get_actions_required/variables.tf
+++ b/codebuild/codebuild_get_actions_required/variables.tf
@@ -8,6 +8,18 @@ variable "pipeline_name" {
   description = "Name of the pipeline"
 }
 
+variable "stage_name" {
+  description = "The name of the pipeline stage"
+  type        = string
+  default     = "default"
+}
+
+variable "action_name" {
+  description = "The name of the pipeline stage action"
+  type        = string
+  default     = "default"
+}
+
 variable "deployment_account_id" {
   description = "The AWS account id where you are deploying to ECR image to."
   type        = string

--- a/codebuild/codebuild_get_changed_file_list/codebuild_get_changed_file_list.tf
+++ b/codebuild/codebuild_get_changed_file_list/codebuild_get_changed_file_list.tf
@@ -1,5 +1,5 @@
 locals {
-  codebuild_project_name = "${var.pipeline_name}-get-changed-file-list-${var.environment}"
+  codebuild_project_name = "${var.pipeline_name}-${var.stage_name}-${var.action_name}"
 }
 
 resource "aws_codebuild_project" "codebuild_get_changed_file_list" {

--- a/codebuild/codebuild_get_changed_file_list/variables.tf
+++ b/codebuild/codebuild_get_changed_file_list/variables.tf
@@ -8,6 +8,18 @@ variable "pipeline_name" {
   description = "Name of the pipeline"
 }
 
+variable "stage_name" {
+  description = "The name of the pipeline stage"
+  type        = string
+  default     = "default"
+}
+
+variable "action_name" {
+  description = "The name of the pipeline stage action"
+  type        = string
+  default     = "default"
+}
+
 variable "deployment_account_id" {
   description = "The AWS account id where you are deploying to ECR image to."
   type        = string

--- a/codebuild/codebuild_test_python_tox_poetry/code_build_test_python_tox_poetry.tf
+++ b/codebuild/codebuild_test_python_tox_poetry/code_build_test_python_tox_poetry.tf
@@ -1,5 +1,5 @@
 locals {
-  codebuild_project_name = "${var.pipeline_name}-python-tox-${var.environment}"
+  codebuild_project_name = "${var.pipeline_name}-${var.stage_name}-${var.action_name}"
 }
 
 resource "aws_codebuild_project" "code_pipeline_test_python_tox_poetry" {

--- a/codebuild/codebuild_test_python_tox_poetry/variables.tf
+++ b/codebuild/codebuild_test_python_tox_poetry/variables.tf
@@ -28,6 +28,18 @@ variable "pipeline_name" {
   type        = string
 }
 
+variable "stage_name" {
+  description = "The name of the pipeline stage"
+  type        = string
+  default     = "default"
+}
+
+variable "action_name" {
+  description = "The name of the pipeline stage action"
+  type        = string
+  default     = "default"
+}
+
 variable "python_source_directory" {
   description = "Directory name where the Python source code is located"
   type        = string

--- a/codebuild/codebuild_validate_terraform/code_build_validate_terraform.tf
+++ b/codebuild/codebuild_validate_terraform/code_build_validate_terraform.tf
@@ -1,5 +1,5 @@
 locals {
-  codebuild_project_name = "${var.pipeline_name}-build-container-docker-hub-${var.environment}"
+  codebuild_project_name = "${var.pipeline_name}-${var.stage_name}-${var.action_name}"
 }
 
 resource "aws_codebuild_project" "code_pipeline_validate_terraform" {

--- a/codebuild/codebuild_validate_terraform/variables.tf
+++ b/codebuild/codebuild_validate_terraform/variables.tf
@@ -44,6 +44,18 @@ variable "pipeline_name" {
   type        = string
 }
 
+variable "stage_name" {
+  description = "The name of the pipeline stage"
+  type        = string
+  default     = "default"
+}
+
+variable "action_name" {
+  description = "The name of the pipeline stage action"
+  type        = string
+  default     = "default"
+}
+
 variable "environment" {
   description = "e.g. staging, production"
   type        = string


### PR DESCRIPTION
If we derive the module name from just the pipeline name then we can't have multiple instances of the same module in the pipeline.

The environment is not enough to differentiate because you might want to build multiple container images for production.