### PR TITLE
CE-267 Refactor artifact handling for changed files modules

### DIFF
--- a/codebuild/codebuild_get_actions_required/codebuild_get_actions_required.tf
+++ b/codebuild/codebuild_get_actions_required/codebuild_get_actions_required.tf
@@ -12,14 +12,6 @@ resource "aws_codebuild_project" "code_pipeline_get_actions_required" {
     type = "CODEPIPELINE"
   }
 
-  secondary_artifacts {
-    type                = "S3"
-    name                = "actions_required.json"
-    artifact_identifier = "actions_required"
-    location            = var.artifact_bucket
-    path                = var.output_artifact_path
-  }
-
   cache {
     type  = "LOCAL"
     modes = ["LOCAL_DOCKER_LAYER_CACHE", "LOCAL_SOURCE_CACHE"]
@@ -44,8 +36,18 @@ resource "aws_codebuild_project" "code_pipeline_get_actions_required" {
     }
 
     environment_variable {
-      name  = "ACTION_TRIGGERS"
-      value = var.action_triggers
+      name  = "CHANGED_FILES_JSON"
+      value = var.changed_files_json
+    }
+
+    environment_variable {
+      name  = "ACTION_TRIGGERS_JSON"
+      value = var.action_triggers_json
+    }
+
+    environment_variable {
+      name  = "OUTPUT_ARTIFACT_PATH"
+      value = var.output_artifact_path
     }
   }
 

--- a/codebuild/codebuild_get_actions_required/codebuild_get_actions_required.yml
+++ b/codebuild/codebuild_get_actions_required/codebuild_get_actions_required.yml
@@ -6,14 +6,17 @@ env:
 phases:
   build:
     commands:
+      - -e
       - echo getting required actions...
-      - python /usr/local/bin/get_actions_required.py
+      - |
+        get_actions_required.py \
+          -c $CHANGED_FILES_JSON \
+          -t $ACTION_TRIGGERS_JSON \
+          -o /opt/$OUTPUT_ARTIFACT_PATH
 
 artifacts:
+  name: ActionsRequired
   files:
-    - "**/*"
-  secondary-artifacts:
-    actions_required:
-      base-directory: $CODEBUILD_SRC_DIR
-      files: 
-        - actions_required.json
+    - $OUTPUT_ARTIFACT_PATH
+  discard-paths: no
+  base-directory: /opt

--- a/codebuild/codebuild_get_actions_required/variables.tf
+++ b/codebuild/codebuild_get_actions_required/variables.tf
@@ -40,19 +40,34 @@ variable "artifact_bucket" {
   type        = string
 }
 
-variable "output_artifact_path" {
-  description = "the S3 path to store the output atrifact"
-  type        = string
-}
-
 variable "codebuild_image" {
   description = "the image in which you want to run the codebuild task"
   type        = string
 }
 
-variable "action_triggers" {
+
+variable "changed_files_artifact" {
+  description = "the input artifact containing the changed files json file."
+  type        = string
+  default     = "changed_files"
+}
+
+variable "changed_files_json" {
+  description = "the path to the changed_files.json file in your repo (can include artifact var)."
+  type        = string
+  default     = "$CODEBUILD_SRC_DIR_changed_files/changed_files.json"
+}
+
+variable "action_triggers_json" {
   description = "the path to the action_triggers.json file in your repo, relative to the root of the repo."
   type        = string
+  default     = "$CODEBUILD_SRC_DIR/terraform/deployments/670214072732/action_triggers.json"
+}
+
+variable "output_artifact_path" {
+  description = "The file name to be created"
+  type        = string
+  default     = "actions_required.json"
 }
 
 variable "tags" {

--- a/codebuild/codebuild_get_changed_file_list/codebuild_get_changed_file_list.tf
+++ b/codebuild/codebuild_get_changed_file_list/codebuild_get_changed_file_list.tf
@@ -64,6 +64,11 @@ resource "aws_codebuild_project" "codebuild_get_changed_file_list" {
       value = var.repo_name
     }
 
+    environment_variable {
+      name  = "OUTPUT_ARTIFACT_PATH"
+      value = var.output_artifact_path
+    }
+
   }
 
   source {

--- a/codebuild/codebuild_get_changed_file_list/codebuild_get_changed_file_list.yml
+++ b/codebuild/codebuild_get_changed_file_list/codebuild_get_changed_file_list.yml
@@ -6,15 +6,13 @@ env:
 phases:
   build:
     commands:
+      - -e
       - echo outputting git diff file...
-      - cd $CODEBUILD_SRC_DIR
-      - source /usr/local/bin/get_pr_changed_files_list.sh ${REPO_NAME} changed_files.json
+      - get_pr_changed_files_list.sh ${REPO_NAME} /opt/$OUTPUT_ARTIFACT_PATH
 
 artifacts:
+  name: ChangedFiles
   files:
-    - "**/*"
-  secondary-artifacts:
-    changed_files:
-      base-directory: $CODEBUILD_SRC_DIR
-      files: 
-        - changed_files.json
+    - $OUTPUT_ARTIFACT_PATH
+  discard-paths: no
+  base-directory: /opt

--- a/codebuild/codebuild_get_changed_file_list/variables.tf
+++ b/codebuild/codebuild_get_changed_file_list/variables.tf
@@ -51,14 +51,10 @@ variable "repo_name" {
   type        = string
 }
 
-variable "artifact_bucket" {
-  description = "S3 path where the artifact will be stored."
-  type        = string
-}
-
 variable "output_artifact_path" {
   description = "the S3 path to store the output atrifact"
   type        = string
+  default     = "changed_files.json"
 }
 
 variable "codebuild_image" {


### PR DESCRIPTION
Both of these were using a secondary artifact to write to the same S3 bucket in a specified location rather than letting codepipeline handle the location of the input/output artifacts. This works more like concourse where you just specify the output in the codepipeline action and write to the output from the buildspec.yml without the requirement for a secondary artifact. 