### PR TITLE
Fix module defaults

### DIFF
--- a/codebuild/codebuild_get_actions_required/variables.tf
+++ b/codebuild/codebuild_get_actions_required/variables.tf
@@ -49,7 +49,7 @@ variable "changed_files_artifact" {
 variable "changed_files_json" {
   description = "the path to the changed_files.json file in your repo (can include artifact var)."
   type        = string
-  default     = "$CODEBUILD_SRC_DIR_changed_files/changed_files.json"
+  default     = "/changed_files.json"
 }
 
 variable "action_triggers_artifact" {
@@ -61,7 +61,7 @@ variable "action_triggers_artifact" {
 variable "action_triggers_json" {
   description = "the path to the action_triggers.json file in your repo, relative to the root of the repo."
   type        = string
-  default     = "$CODEBUILD_SRC_DIR/terraform/deployments/670214072732/action_triggers.json"
+  default     = "/terraform/deployments/670214072732/action_triggers.json"
 }
 
 variable "output_artifact_path" {


### PR DESCRIPTION
Previously I was trying to pass in the CODEBUILD_SRC vars in env
vars. We could do that with something nasty like an eval but
instead I've just passed the path within the artifact and the
artifact name as a separate var.

The bash then figures out the env var name and resolves the path
from it.

The defaults should now work if you don't specify any of these
vars but it means that you can choose to save the files to
artifact names or file names of your choosing.