### PR TITLE
CE-264: Shorten name of event rule

### DIFF
--- a/cloudwatch/cloudwatch_report_codepipeline_status/cloudwatch.tf
+++ b/cloudwatch/cloudwatch_report_codepipeline_status/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_event_rule" "codepipeline_event_rule" {
-  name        = "codepipeline-${var.pipeline_name}-healthcheck-event-rule"
+  name        = "codepipeline-events-${var.pipeline_name}"
   description = "Codepipeline Execution State Change"
 
   event_pattern = <<EOF

--- a/cloudwatch/cloudwatch_report_codepipeline_status/cloudwatch.tf
+++ b/cloudwatch/cloudwatch_report_codepipeline_status/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_event_rule" "codepipeline_event_rule" {
-  name        = "codepipeline-events-${var.pipeline_name}"
+  name        = "codepipeline-events-${substr(var.pipeline_name, 0, 44)}"
   description = "Codepipeline Execution State Change"
 
   event_pattern = <<EOF


### PR DESCRIPTION
Was causing issues with long pipeline names since an event rule can only have 64 characters in its name.