### PR TITLE
Fix S3 log shipping docs

### DIFF
--- a/s3/s3_log_shipping/README.md
+++ b/s3/s3_log_shipping/README.md
@@ -7,13 +7,13 @@ resources to grant access.
 ## Instructions
 
 ### Import module
-Import the module into your terraform
+Import the module into your terraform. Ask the Cyber Security Team for the lambda role ARN.
 
 ``` hcl
 module "s3_log_shipping" {
-  source  = "github.com/alphagov/cyber-security-shared-terraform-modules//s3/s3_log_shipping"
-  sqs_arn = aws_sqs_queue.YOUR_SQS.arn
-  s3_name  = aws_s3_bucket.YOUR_BUCKET.id
+  source                    = "github.com/alphagov/cyber-security-shared-terraform-modules//s3/s3_log_shipping"
+  s3_name                   = aws_s3_bucket.YOUR_BUCKET.id
+  s3_processor_lambda_role  = data.aws_iam_role.lambda_role.arn
 }
 ```
 

--- a/s3/s3_log_shipping/README.md
+++ b/s3/s3_log_shipping/README.md
@@ -36,22 +36,6 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
 }
 ```
 
-Repeat the policy combination and application for the SQS queue.
-
-``` hcl
-data "aws_iam_policy_document" "sqs_combined" {
-  source_policy_documents = [
-    data.aws_iam_policy_document.YOUR_SQS_POLICY.json,
-    module.s3_log_shipping.sqs_policy
-  ]
-}
-
-resource "aws_sqs_queue_policy" "queue_policy" {
-  queue_url = aws_sqs_queue.YOUR_SQS.id
-  policy    = data.aws_iam_policy_document.sqs_combined.json
-}
-```
-
 ## What the Lambda maintainers need to do afterwards
 
 Once this is all set up, the maintainers of the s3 processor lambda


### PR DESCRIPTION
Alice Carr had some difficulties in setting up this module, and it turned out that the documentation
was out of sync with the Terraform module itself. This PR updates the README to bring it in line
with how it should work.

To reiterate my second commit message, I'm not really sure why we removed the SQS-related parts of
this module, and I do wonder if it's related to some of the issues we're having with getting third
party users on to CSLS' S3 processor. That's a problem for another day though.
